### PR TITLE
Bug/rm trigger

### DIFF
--- a/db/mock/store.go
+++ b/db/mock/store.go
@@ -611,6 +611,20 @@ func (mr *MockStoreMockRecorder) GetWorkout(arg0, arg1 interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkout", reflect.TypeOf((*MockStore)(nil).GetWorkout), arg0, arg1)
 }
 
+// InsertInactiveUser mocks base method.
+func (m *MockStore) InsertInactiveUser(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InsertInactiveUser", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InsertInactiveUser indicates an expected call of InsertInactiveUser.
+func (mr *MockStoreMockRecorder) InsertInactiveUser(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertInactiveUser", reflect.TypeOf((*MockStore)(nil).InsertInactiveUser), arg0, arg1)
+}
+
 // ListCategories mocks base method.
 func (m *MockStore) ListCategories(arg0 context.Context) ([]db.Category, error) {
 	m.ctrl.T.Helper()

--- a/db/query/inactive.sql
+++ b/db/query/inactive.sql
@@ -1,3 +1,6 @@
+-- name: InsertInactiveUser :exec
+INSERT INTO `inactive_user` (id) VALUES (UUID_TO_BIN(sqlc.arg('user_id')));
+
 -- name: GetInactiveUser :one
 SELECT BIN_TO_UUID(id) AS id FROM
 `inactive_user` WHERE id = UUID_TO_BIN(sqlc.arg('user_id'));

--- a/db/sqlc/db.go
+++ b/db/sqlc/db.go
@@ -141,6 +141,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.getWorkoutStmt, err = db.PrepareContext(ctx, getWorkout); err != nil {
 		return nil, fmt.Errorf("error preparing query GetWorkout: %w", err)
 	}
+	if q.insertInactiveUserStmt, err = db.PrepareContext(ctx, insertInactiveUser); err != nil {
+		return nil, fmt.Errorf("error preparing query InsertInactiveUser: %w", err)
+	}
 	if q.listCategoriesStmt, err = db.PrepareContext(ctx, listCategories); err != nil {
 		return nil, fmt.Errorf("error preparing query ListCategories: %w", err)
 	}
@@ -389,6 +392,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing getWorkoutStmt: %w", cerr)
 		}
 	}
+	if q.insertInactiveUserStmt != nil {
+		if cerr := q.insertInactiveUserStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing insertInactiveUserStmt: %w", cerr)
+		}
+	}
 	if q.listCategoriesStmt != nil {
 		if cerr := q.listCategoriesStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing listCategoriesStmt: %w", cerr)
@@ -547,6 +555,7 @@ type Queries struct {
 	getUserByEmailStmt           *sql.Stmt
 	getUserByIdStmt              *sql.Stmt
 	getWorkoutStmt               *sql.Stmt
+	insertInactiveUserStmt       *sql.Stmt
 	listCategoriesStmt           *sql.Stmt
 	listExercisesStmt            *sql.Stmt
 	listLiftsFromWorkoutStmt     *sql.Stmt
@@ -608,6 +617,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		getUserByEmailStmt:           q.getUserByEmailStmt,
 		getUserByIdStmt:              q.getUserByIdStmt,
 		getWorkoutStmt:               q.getWorkoutStmt,
+		insertInactiveUserStmt:       q.insertInactiveUserStmt,
 		listCategoriesStmt:           q.listCategoriesStmt,
 		listExercisesStmt:            q.listExercisesStmt,
 		listLiftsFromWorkoutStmt:     q.listLiftsFromWorkoutStmt,

--- a/db/sqlc/inactive.sql.go
+++ b/db/sqlc/inactive.sql.go
@@ -20,3 +20,12 @@ func (q *Queries) GetInactiveUser(ctx context.Context, userID string) (string, e
 	err := row.Scan(&id)
 	return id, err
 }
+
+const insertInactiveUser = `-- name: InsertInactiveUser :exec
+INSERT INTO ` + "`" + `inactive_user` + "`" + ` (id) VALUES (UUID_TO_BIN(?))
+`
+
+func (q *Queries) InsertInactiveUser(ctx context.Context, userID string) error {
+	_, err := q.exec(ctx, q.insertInactiveUserStmt, insertInactiveUser, userID)
+	return err
+}

--- a/db/sqlc/inactive_test.go
+++ b/db/sqlc/inactive_test.go
@@ -1,0 +1,20 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueueUserDeletion(t *testing.T) {
+	user := GenRandUser(t)
+
+	err := testQueries.InsertInactiveUser(context.Background(), user.ID)
+	require.NoError(t, err)
+
+	inactiveUserID, err := testQueries.GetInactiveUser(context.Background(), user.ID)
+	require.NoError(t, err)
+
+	require.Equal(t, user.ID, inactiveUserID)
+}

--- a/db/sqlc/main_test.go
+++ b/db/sqlc/main_test.go
@@ -1,12 +1,9 @@
 package db
 
 import (
-	"bufio"
-	"context"
 	"database/sql"
 	"log"
 	"os"
-	"strings"
 	"testing"
 
 	_ "github.com/go-sql-driver/mysql"
@@ -28,23 +25,6 @@ func TestMain(m *testing.M) {
 	}
 
 	testQueries = New(testDB)
-
-	//@todo - revist. Triggers won't run with sqlc. Using as temp solution
-	file, err := os.Open("../trigger/inactive.sql")
-	if err != nil {
-		log.Fatal("cannot read trigger file")
-	}
-
-	defer file.Close()
-
-	var lines []string
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		lines = append(lines, scanner.Text())
-	}
-	// skipping err so I don't have to check if trigger has been created already.
-	// will revisit
-	testDB.ExecContext(context.Background(), strings.Join(lines, " "))
 
 	os.Exit(m.Run())
 }

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -49,6 +49,7 @@ type Querier interface {
 	GetUserByEmail(ctx context.Context, emailAddress string) (GetUserByEmailRow, error)
 	GetUserById(ctx context.Context, userID string) (GetUserByIdRow, error)
 	GetWorkout(ctx context.Context, arg GetWorkoutParams) (Workout, error)
+	InsertInactiveUser(ctx context.Context, userID string) error
 	ListCategories(ctx context.Context) ([]Category, error)
 	ListExercises(ctx context.Context, userID string) ([]Exercise, error)
 	ListLiftsFromWorkout(ctx context.Context, arg ListLiftsFromWorkoutParams) ([]Lift, error)

--- a/db/sqlc/user_test.go
+++ b/db/sqlc/user_test.go
@@ -104,11 +104,7 @@ func TestUpdateEmail(t *testing.T) {
 
 func TestChangePassword(t *testing.T) {
 	user := GenRandUser(t)
-	require.Equal(
-		t,
-		user.PasswordChangedAt.Year(),
-		1970,
-	) // indicates password has never been changed
+	require.Equal(t, user.PasswordChangedAt.Year(), 1970) // indicates password has never been changed
 
 	newPassword := util.RandomStr(12)
 	err := testQueries.ChangePassword(context.Background(), ChangePasswordParams{
@@ -131,12 +127,6 @@ func TestDeleteUser(t *testing.T) {
 
 	_, err = testQueries.GetUserByEmail(context.Background(), user.EmailAddress)
 	require.Error(t, err)
-
-	inactiveUserID, err := testQueries.GetInactiveUser(context.Background(), user.ID)
-	require.NoError(t, err)
-
-	// trigger is set to insert the deleted user id into inactive user table
-	require.Equal(t, inactiveUserID, user.ID)
 }
 
 func GenRandUser(t *testing.T) GetUserByEmailRow {
@@ -160,11 +150,7 @@ func GenRandUser(t *testing.T) GetUserByEmailRow {
 	require.Equal(t, args.FirstName, user.FirstName)
 	require.Equal(t, args.LastName, user.LastName)
 	require.Equal(t, args.EmailAddress, user.EmailAddress)
-	require.Equal(
-		t,
-		user.PasswordChangedAt.Year(),
-		1970,
-	) // indicates the password has never been changed
+	require.Equal(t, user.PasswordChangedAt.Year(), 1970) // indicates the password has never been changed
 	require.GreaterOrEqual(t, len(args.Password), 10)
 	require.NotEqual(t, password, user.Password)
 	require.Equal(t, hashedPassword, user.Password)

--- a/db/trigger/inactive.sql
+++ b/db/trigger/inactive.sql
@@ -1,1 +1,0 @@
-CREATE TRIGGER inactive AFTER DELETE ON user FOR EACH ROW INSERT INTO inactive_user (id) VALUES (OLD.id);


### PR DESCRIPTION
Welp, back at it again with not reading documentation and checking what is supported in planet scale. Triggers are not allowed, removing and placing a simple insert statement in the delete user API to keep track of inactive users. Batch deletions will still be ran. 