### PR TITLE
Bug/session

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -179,8 +179,8 @@ func (server *Server) renewToken(ctx *gin.Context) {
 		return
 	}
 
-	// check for validation only when session ID is pulled from http only cookie.
-	// when caller makes request with refreshToken, we skip verifying the token below
+	// this check is invoked only when the session ID is pulled from http cookie.
+	// when caller makes request with refresh token, this check is not hit
 	if !req.Validated {
 		payload, err := server.tokenMaker.VerifyToken(session.RefreshToken)
 		if err != nil {

--- a/api/server.go
+++ b/api/server.go
@@ -45,6 +45,7 @@ func (server *Server) setupCors(router *gin.Engine) {
 	config.AllowOrigins = origins
 	config.AllowMethods = []string{"GET", "POST", "PATCH", "DELETE"}
 	config.AllowHeaders = []string{"Origin", "Content-Type", "Authorization"}
+	config.AllowCredentials = true
 	router.Use(cors.New(config))
 }
 

--- a/api/server.go
+++ b/api/server.go
@@ -34,6 +34,11 @@ func NewServer(config util.Config, store db.Store) (*Server, error) {
 	return server, nil
 }
 
+func writeHeaders(ctx *gin.Context) {
+	// max browser preflight cache time for chromium
+	ctx.Writer.Header().Set("Access-Control-Max-Age", "7200")
+}
+
 func (server *Server) setupCors(router *gin.Engine) {
 	config := cors.DefaultConfig()
 	origins := strings.Split(server.config.AllowedOrigins, ",")
@@ -45,6 +50,7 @@ func (server *Server) setupCors(router *gin.Engine) {
 
 func (server *Server) setupRouter() {
 	router := gin.Default()
+	router.Use(writeHeaders)
 	server.setupCors(router)
 
 	router.POST("/createUser", server.createUser)

--- a/api/user.go
+++ b/api/user.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	USERID_NOT_FOUND            = "user with specified ID '%s' does not exist"
-	USEREMAIL_NOT_FOUND         = "user with specified eMail '%s' does not exist"
+	USEREMAIL_NOT_FOUND         = "%s is not registered to an account"
 	LOGGED_IN_USER_DOESNT_MATCH = "authenticated user does not match the requested account"
 )
 
@@ -28,10 +28,10 @@ type UserResponse struct {
 }
 
 type createUserRequest struct {
-	FirstName    string `json:"firstName" binding:"required"`
-	LastName     string `json:"lastName" binding:"required"`
+	FirstName    string `json:"firstName"    binding:"required"`
+	LastName     string `json:"lastName"     binding:"required"`
 	EmailAddress string `json:"emailAddress" binding:"required,email"`
-	Password     string `json:"password" binding:"required,gt=8"`
+	Password     string `json:"password"     binding:"required,gt=8"`
 }
 
 func (server *Server) createUser(ctx *gin.Context) {
@@ -63,7 +63,10 @@ func (server *Server) createUser(ctx *gin.Context) {
 	user, err := server.store.GetUserByEmail(ctx, req.EmailAddress)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			ctx.JSON(http.StatusNotFound, errorResponse(fmt.Errorf(USEREMAIL_NOT_FOUND, req.EmailAddress)))
+			ctx.JSON(
+				http.StatusNotFound,
+				errorResponse(fmt.Errorf(USEREMAIL_NOT_FOUND, req.EmailAddress)),
+			)
 			return
 		}
 		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
@@ -95,7 +98,10 @@ func (server *Server) getUserByEmail(ctx *gin.Context) {
 	user, err := server.store.GetUserByEmail(ctx, req.EmailAddress)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			ctx.JSON(http.StatusNotFound, errorResponse(fmt.Errorf(USEREMAIL_NOT_FOUND, req.EmailAddress)))
+			ctx.JSON(
+				http.StatusNotFound,
+				errorResponse(fmt.Errorf(USEREMAIL_NOT_FOUND, req.EmailAddress)),
+			)
 			return
 		}
 		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
@@ -120,7 +126,7 @@ type updateUserRequest struct {
 	FirstName    string `json:"firstName"`
 	LastName     string `json:"lastName"`
 	EmailAddress string `json:"emailAddress" binding:"omitempty,email"`
-	ID           string `json:"id" binding:"required"`
+	ID           string `json:"id"           binding:"required"`
 }
 
 func (server *Server) updateUser(ctx *gin.Context) {
@@ -186,9 +192,9 @@ func (server *Server) updateUser(ctx *gin.Context) {
 }
 
 type changePasswordRequest struct {
-	ID              string `json:"id" binding:"required"`
+	ID              string `json:"id"              binding:"required"`
 	CurrentPassword string `json:"currentPassword" binding:"required,gt=8"`
-	NewPassword     string `json:"newPassword" binding:"required,gt=8"`
+	NewPassword     string `json:"newPassword"     binding:"required,gt=8"`
 }
 
 func (server *Server) changePassword(ctx *gin.Context) {
@@ -216,7 +222,10 @@ func (server *Server) changePassword(ctx *gin.Context) {
 	}
 
 	if user.Password != req.CurrentPassword {
-		ctx.JSON(http.StatusUnauthorized, errorResponse(errors.New("your current password is incorrect")))
+		ctx.JSON(
+			http.StatusUnauthorized,
+			errorResponse(errors.New("your current password is incorrect")),
+		)
 		return
 	}
 


### PR DESCRIPTION
- updated session error handling
- when a new login occurs, previous session(s) are deleted
- http only cookie is set when user logins. The cookie is then used to keep the user logged in for a longer period of time. The session can be validated on the client side if they log out or close the page and come back within the refresh token duration.
- updated some of the headers to accept the credentials header and set the max preflight cache time so the client doesn't make an options request every 5 seconds. 