### PR TITLE
Routes/session

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -118,6 +118,7 @@ func (server *Server) login(ctx *gin.Context) {
 		Expires:  session.ExpiresAt,
 		SameSite: http.SameSiteStrictMode,
 		MaxAge:   3600,
+		Path:     "/api",
 	})
 
 	ctx.JSON(http.StatusOK, loginResponse{

--- a/api/exercise_test.go
+++ b/api/exercise_test.go
@@ -46,7 +46,14 @@ func TestCreateExercise(t *testing.T) {
 			Name: "Bad Request",
 			Body: gin.H{},
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
@@ -62,7 +69,14 @@ func TestCreateExercise(t *testing.T) {
 				"userID":       userID.String(),
 			},
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
 				args := db.CreateExerciseParams{
@@ -71,7 +85,10 @@ func TestCreateExercise(t *testing.T) {
 					Category:    exercise.Category,
 					UserID:      userID.String(),
 				}
-				store.EXPECT().CreateExercise(gomock.Any(), gomock.Eq(args)).Times(1).Return(int64(0), sql.ErrConnDone)
+				store.EXPECT().
+					CreateExercise(gomock.Any(), gomock.Eq(args)).
+					Times(1).
+					Return(int64(0), sql.ErrConnDone)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusInternalServerError, recorder.Code)
@@ -86,7 +103,14 @@ func TestCreateExercise(t *testing.T) {
 				"userID":       userID.String(),
 			},
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
 				args := db.CreateExerciseParams{
@@ -95,9 +119,14 @@ func TestCreateExercise(t *testing.T) {
 					Category:    exercise.Category,
 					UserID:      userID.String(),
 				}
-				store.EXPECT().CreateExercise(gomock.Any(), gomock.Eq(args)).Times(1).Return(int64(exercise.ID), nil)
-				store.EXPECT().GetExercise(gomock.Any(), gomock.Eq(db.GetExerciseParams{ID: exercise.ID, UserID: userID.String()})).
-					Times(1).Return(db.Exercise{}, sql.ErrNoRows)
+				store.EXPECT().
+					CreateExercise(gomock.Any(), gomock.Eq(args)).
+					Times(1).
+					Return(int64(exercise.ID), nil)
+				store.EXPECT().
+					GetExercise(gomock.Any(), gomock.Eq(db.GetExerciseParams{ID: exercise.ID, UserID: userID.String()})).
+					Times(1).
+					Return(db.Exercise{}, sql.ErrNoRows)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusNotFound, recorder.Code)
@@ -112,7 +141,14 @@ func TestCreateExercise(t *testing.T) {
 				"userID":       userID.String(),
 			},
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
 				args := db.CreateExerciseParams{
@@ -121,9 +157,14 @@ func TestCreateExercise(t *testing.T) {
 					Category:    exercise.Category,
 					UserID:      userID.String(),
 				}
-				store.EXPECT().CreateExercise(gomock.Any(), gomock.Eq(args)).Times(1).Return(int64(exercise.ID), nil)
-				store.EXPECT().GetExercise(gomock.Any(), gomock.Eq(db.GetExerciseParams{ID: exercise.ID, UserID: userID.String()})).
-					Times(1).Return(db.Exercise{}, sql.ErrConnDone)
+				store.EXPECT().
+					CreateExercise(gomock.Any(), gomock.Eq(args)).
+					Times(1).
+					Return(int64(exercise.ID), nil)
+				store.EXPECT().
+					GetExercise(gomock.Any(), gomock.Eq(db.GetExerciseParams{ID: exercise.ID, UserID: userID.String()})).
+					Times(1).
+					Return(db.Exercise{}, sql.ErrConnDone)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusInternalServerError, recorder.Code)
@@ -138,7 +179,14 @@ func TestCreateExercise(t *testing.T) {
 				"userID":       userID.String(),
 			},
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
 				args := db.CreateExerciseParams{
@@ -147,9 +195,14 @@ func TestCreateExercise(t *testing.T) {
 					Category:    exercise.Category,
 					UserID:      userID.String(),
 				}
-				store.EXPECT().CreateExercise(gomock.Any(), gomock.Eq(args)).Times(1).Return(int64(exercise.ID), nil)
-				store.EXPECT().GetExercise(gomock.Any(), gomock.Eq(db.GetExerciseParams{ID: exercise.ID, UserID: userID.String()})).
-					Times(1).Return(exercise, nil)
+				store.EXPECT().
+					CreateExercise(gomock.Any(), gomock.Eq(args)).
+					Times(1).
+					Return(int64(exercise.ID), nil)
+				store.EXPECT().
+					GetExercise(gomock.Any(), gomock.Eq(db.GetExerciseParams{ID: exercise.ID, UserID: userID.String()})).
+					Times(1).
+					Return(exercise, nil)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusOK, recorder.Code)
@@ -187,7 +240,7 @@ func TestCreateExercise(t *testing.T) {
 			payload, err := json.Marshal(tc.Body)
 			require.NoError(t, err)
 
-			url := "/createExercise"
+			url := "/api/createExercise"
 			request, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(payload))
 			require.NoError(t, err)
 

--- a/api/profile_test.go
+++ b/api/profile_test.go
@@ -37,7 +37,14 @@ func TestCreateProfile(t *testing.T) {
 			Name: "Bad Request",
 			Body: gin.H{},
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
 			},
@@ -56,7 +63,14 @@ func TestCreateProfile(t *testing.T) {
 				"userID":            userID.String(),
 			},
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
 				args := db.CreateProfileParams{
@@ -67,7 +81,10 @@ func TestCreateProfile(t *testing.T) {
 					TimezoneOffset:    profile.TimezoneOffset,
 					UserID:            userID.String(),
 				}
-				store.EXPECT().CreateProfile(gomock.Any(), gomock.Eq(args)).Times(1).Return(int64(0), sql.ErrConnDone)
+				store.EXPECT().
+					CreateProfile(gomock.Any(), gomock.Eq(args)).
+					Times(1).
+					Return(int64(0), sql.ErrConnDone)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusInternalServerError, recorder.Code)
@@ -84,7 +101,14 @@ func TestCreateProfile(t *testing.T) {
 				"userID":            userID.String(),
 			},
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
 				args := db.CreateProfileParams{
@@ -95,8 +119,14 @@ func TestCreateProfile(t *testing.T) {
 					TimezoneOffset:    profile.TimezoneOffset,
 					UserID:            userID.String(),
 				}
-				store.EXPECT().CreateProfile(gomock.Any(), gomock.Eq(args)).Times(1).Return(int64(profile.ID), nil)
-				store.EXPECT().GetProfile(gomock.Any(), gomock.Eq(userID.String())).Times(1).Return(db.Profile{}, sql.ErrNoRows)
+				store.EXPECT().
+					CreateProfile(gomock.Any(), gomock.Eq(args)).
+					Times(1).
+					Return(int64(profile.ID), nil)
+				store.EXPECT().
+					GetProfile(gomock.Any(), gomock.Eq(userID.String())).
+					Times(1).
+					Return(db.Profile{}, sql.ErrNoRows)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusNotFound, recorder.Code)
@@ -113,7 +143,14 @@ func TestCreateProfile(t *testing.T) {
 				"userID":            userID.String(),
 			},
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
 				args := db.CreateProfileParams{
@@ -124,8 +161,14 @@ func TestCreateProfile(t *testing.T) {
 					TimezoneOffset:    profile.TimezoneOffset,
 					UserID:            userID.String(),
 				}
-				store.EXPECT().CreateProfile(gomock.Any(), gomock.Eq(args)).Times(1).Return(int64(profile.ID), nil)
-				store.EXPECT().GetProfile(gomock.Any(), gomock.Eq(userID.String())).Times(1).Return(db.Profile{}, sql.ErrConnDone)
+				store.EXPECT().
+					CreateProfile(gomock.Any(), gomock.Eq(args)).
+					Times(1).
+					Return(int64(profile.ID), nil)
+				store.EXPECT().
+					GetProfile(gomock.Any(), gomock.Eq(userID.String())).
+					Times(1).
+					Return(db.Profile{}, sql.ErrConnDone)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusInternalServerError, recorder.Code)
@@ -142,7 +185,14 @@ func TestCreateProfile(t *testing.T) {
 				"userID":            userID.String(),
 			},
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
 				args := db.CreateProfileParams{
@@ -153,8 +203,14 @@ func TestCreateProfile(t *testing.T) {
 					TimezoneOffset:    profile.TimezoneOffset,
 					UserID:            userID.String(),
 				}
-				store.EXPECT().CreateProfile(gomock.Any(), gomock.Eq(args)).Times(1).Return(int64(profile.ID), nil)
-				store.EXPECT().GetProfile(gomock.Any(), gomock.Eq(userID.String())).Times(1).Return(profile, nil)
+				store.EXPECT().
+					CreateProfile(gomock.Any(), gomock.Eq(args)).
+					Times(1).
+					Return(int64(profile.ID), nil)
+				store.EXPECT().
+					GetProfile(gomock.Any(), gomock.Eq(userID.String())).
+					Times(1).
+					Return(profile, nil)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusOK, recorder.Code)
@@ -200,7 +256,7 @@ func TestCreateProfile(t *testing.T) {
 			payload, err := json.Marshal(tc.Body)
 			require.NoError(t, err)
 
-			url := "/createProfile"
+			url := "/api/createProfile"
 			request, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(payload))
 			require.NoError(t, err)
 
@@ -226,10 +282,20 @@ func TestGetProfile(t *testing.T) {
 			Name:   "Not Found",
 			UserID: userID.String(),
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
-				store.EXPECT().GetProfile(gomock.Any(), gomock.Eq(userID.String())).Times(1).Return(db.Profile{}, sql.ErrNoRows)
+				store.EXPECT().
+					GetProfile(gomock.Any(), gomock.Eq(userID.String())).
+					Times(1).
+					Return(db.Profile{}, sql.ErrNoRows)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusNotFound, recorder.Code)
@@ -239,10 +305,20 @@ func TestGetProfile(t *testing.T) {
 			Name:   "Internal Error",
 			UserID: userID.String(),
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
-				store.EXPECT().GetProfile(gomock.Any(), gomock.Eq(userID.String())).Times(1).Return(db.Profile{}, sql.ErrConnDone)
+				store.EXPECT().
+					GetProfile(gomock.Any(), gomock.Eq(userID.String())).
+					Times(1).
+					Return(db.Profile{}, sql.ErrConnDone)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusInternalServerError, recorder.Code)
@@ -252,10 +328,20 @@ func TestGetProfile(t *testing.T) {
 			Name:   "OK",
 			UserID: userID.String(),
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
-				store.EXPECT().GetProfile(gomock.Any(), gomock.Eq(userID.String())).Times(1).Return(profile, nil)
+				store.EXPECT().
+					GetProfile(gomock.Any(), gomock.Eq(userID.String())).
+					Times(1).
+					Return(profile, nil)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusOK, recorder.Code)
@@ -291,7 +377,7 @@ func TestGetProfile(t *testing.T) {
 			server := newTestServer(t, store)
 			recorder := httptest.NewRecorder()
 
-			url := fmt.Sprintf("/getProfile/%s", tc.UserID)
+			url := fmt.Sprintf("/api/getProfile/%s", tc.UserID)
 			request, err := http.NewRequest(http.MethodGet, url, nil)
 			require.NoError(t, err)
 
@@ -318,7 +404,14 @@ func TestUpdateProfile(t *testing.T) {
 			Name: "Bad Request",
 			Body: gin.H{},
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
 			},
@@ -337,10 +430,20 @@ func TestUpdateProfile(t *testing.T) {
 				"userID":            userID.String(),
 			},
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
-				store.EXPECT().GetProfile(gomock.Any(), gomock.Eq(userID.String())).Times(1).Return(db.Profile{}, sql.ErrNoRows)
+				store.EXPECT().
+					GetProfile(gomock.Any(), gomock.Eq(userID.String())).
+					Times(1).
+					Return(db.Profile{}, sql.ErrNoRows)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusNotFound, recorder.Code)
@@ -357,10 +460,20 @@ func TestUpdateProfile(t *testing.T) {
 				"userID":            userID.String(),
 			},
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
-				store.EXPECT().GetProfile(gomock.Any(), gomock.Eq(userID.String())).Times(1).Return(db.Profile{}, sql.ErrConnDone)
+				store.EXPECT().
+					GetProfile(gomock.Any(), gomock.Eq(userID.String())).
+					Times(1).
+					Return(db.Profile{}, sql.ErrConnDone)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusInternalServerError, recorder.Code)
@@ -377,11 +490,24 @@ func TestUpdateProfile(t *testing.T) {
 				"userID":            userID.String(),
 			},
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
-				store.EXPECT().GetProfile(gomock.Any(), gomock.Eq(userID.String())).Times(1).Return(profile, nil)
-				store.EXPECT().UpdateProfile(gomock.Any(), gomock.Eq(updateParams)).Times(1).Return(nil, sql.ErrConnDone)
+				store.EXPECT().
+					GetProfile(gomock.Any(), gomock.Eq(userID.String())).
+					Times(1).
+					Return(profile, nil)
+				store.EXPECT().
+					UpdateProfile(gomock.Any(), gomock.Eq(updateParams)).
+					Times(1).
+					Return(nil, sql.ErrConnDone)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusInternalServerError, recorder.Code)
@@ -398,12 +524,28 @@ func TestUpdateProfile(t *testing.T) {
 				"userID":            userID.String(),
 			},
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
-				store.EXPECT().GetProfile(gomock.Any(), gomock.Eq(userID.String())).Times(1).Return(profile, nil)
-				store.EXPECT().UpdateProfile(gomock.Any(), gomock.Eq(updateParams)).Times(1).Return(nil, nil)
-				store.EXPECT().GetProfile(gomock.Any(), gomock.Eq(userID.String())).Times(1).Return(db.Profile{}, sql.ErrConnDone)
+				store.EXPECT().
+					GetProfile(gomock.Any(), gomock.Eq(userID.String())).
+					Times(1).
+					Return(profile, nil)
+				store.EXPECT().
+					UpdateProfile(gomock.Any(), gomock.Eq(updateParams)).
+					Times(1).
+					Return(nil, nil)
+				store.EXPECT().
+					GetProfile(gomock.Any(), gomock.Eq(userID.String())).
+					Times(1).
+					Return(db.Profile{}, sql.ErrConnDone)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusInternalServerError, recorder.Code)
@@ -420,12 +562,28 @@ func TestUpdateProfile(t *testing.T) {
 				"userID":            userID.String(),
 			},
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
-				store.EXPECT().GetProfile(gomock.Any(), gomock.Eq(userID.String())).Times(1).Return(profile, nil)
-				store.EXPECT().UpdateProfile(gomock.Any(), gomock.Eq(updateParams)).Times(1).Return(nil, nil)
-				store.EXPECT().GetProfile(gomock.Any(), gomock.Eq(userID.String())).Times(1).Return(updatedProfile, nil)
+				store.EXPECT().
+					GetProfile(gomock.Any(), gomock.Eq(userID.String())).
+					Times(1).
+					Return(profile, nil)
+				store.EXPECT().
+					UpdateProfile(gomock.Any(), gomock.Eq(updateParams)).
+					Times(1).
+					Return(nil, nil)
+				store.EXPECT().
+					GetProfile(gomock.Any(), gomock.Eq(userID.String())).
+					Times(1).
+					Return(updatedProfile, nil)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusOK, recorder.Code)
@@ -471,7 +629,7 @@ func TestUpdateProfile(t *testing.T) {
 			server := newTestServer(t, store)
 			recorder := httptest.NewRecorder()
 
-			url := "/updateProfile"
+			url := "/api/updateProfile"
 			request, err := http.NewRequest(http.MethodPatch, url, bytes.NewReader(data))
 			require.NoError(t, err)
 
@@ -497,10 +655,20 @@ func TestDeleteProfile(t *testing.T) {
 			Name:   "Not Found -> Get Profile",
 			UserID: userID.String(),
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
-				store.EXPECT().GetProfile(gomock.Any(), gomock.Eq(userID.String())).Times(1).Return(db.Profile{}, sql.ErrNoRows)
+				store.EXPECT().
+					GetProfile(gomock.Any(), gomock.Eq(userID.String())).
+					Times(1).
+					Return(db.Profile{}, sql.ErrNoRows)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusNotFound, recorder.Code)
@@ -510,10 +678,20 @@ func TestDeleteProfile(t *testing.T) {
 			Name:   "Internal Error -> Get Profile",
 			UserID: userID.String(),
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
-				store.EXPECT().GetProfile(gomock.Any(), gomock.Eq(userID.String())).Times(1).Return(db.Profile{}, sql.ErrConnDone)
+				store.EXPECT().
+					GetProfile(gomock.Any(), gomock.Eq(userID.String())).
+					Times(1).
+					Return(db.Profile{}, sql.ErrConnDone)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusInternalServerError, recorder.Code)
@@ -523,11 +701,24 @@ func TestDeleteProfile(t *testing.T) {
 			Name:   "Internal Error -> Delete Profile",
 			UserID: userID.String(),
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
-				store.EXPECT().GetProfile(gomock.Any(), gomock.Eq(userID.String())).Times(1).Return(profile, nil)
-				store.EXPECT().DeleteProfile(gomock.Any(), gomock.Eq(userID.String())).Times(1).Return(sql.ErrConnDone)
+				store.EXPECT().
+					GetProfile(gomock.Any(), gomock.Eq(userID.String())).
+					Times(1).
+					Return(profile, nil)
+				store.EXPECT().
+					DeleteProfile(gomock.Any(), gomock.Eq(userID.String())).
+					Times(1).
+					Return(sql.ErrConnDone)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusInternalServerError, recorder.Code)
@@ -537,11 +728,24 @@ func TestDeleteProfile(t *testing.T) {
 			Name:   "OK -> No Content",
 			UserID: userID.String(),
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
-				store.EXPECT().GetProfile(gomock.Any(), gomock.Eq(userID.String())).Times(1).Return(profile, nil)
-				store.EXPECT().DeleteProfile(gomock.Any(), gomock.Eq(userID.String())).Times(1).Return(nil)
+				store.EXPECT().
+					GetProfile(gomock.Any(), gomock.Eq(userID.String())).
+					Times(1).
+					Return(profile, nil)
+				store.EXPECT().
+					DeleteProfile(gomock.Any(), gomock.Eq(userID.String())).
+					Times(1).
+					Return(nil)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusNoContent, recorder.Code)
@@ -571,7 +775,7 @@ func TestDeleteProfile(t *testing.T) {
 			server := newTestServer(t, store)
 			recorder := httptest.NewRecorder()
 
-			url := fmt.Sprintf("/deleteProfile/%s", tc.UserID)
+			url := fmt.Sprintf("/api/deleteProfile/%s", tc.UserID)
 			request, err := http.NewRequest(http.MethodDelete, url, nil)
 			require.NoError(t, err)
 

--- a/api/server.go
+++ b/api/server.go
@@ -54,11 +54,14 @@ func (server *Server) setupRouter() {
 	router.Use(writeHeaders)
 	server.setupCors(router)
 
-	router.POST("/createUser", server.createUser)
-	router.POST("/auth/login", server.login)
-	router.POST("/auth/renewToken", server.renewToken)
+	api := router.Group("/api")
 
-	protected := router.Group("/").Use(authMiddleware(server.tokenMaker))
+	api.POST("/createUser", server.createUser)
+	api.POST("/auth/login", server.login)
+	api.POST("/auth/renewToken", server.renewToken)
+	api.GET("/validateSession", server.validateSession)
+
+	protected := api.Group("").Use(authMiddleware(server.tokenMaker))
 
 	protected.GET("/getUserByEmail/:email", server.getUserByEmail)
 	protected.PATCH("/updateUser", server.updateUser)

--- a/api/session.go
+++ b/api/session.go
@@ -38,29 +38,3 @@ func (server *Server) validateSession(ctx *gin.Context) {
 		IsLoggedIn: time.Now().Before(session.ExpiresAt),
 	})
 }
-
-// type getSessionResponse struct {
-// 	IsLoggedIn bool `json:"isLoggedIn"`
-// }
-
-// func (server *Server) getSession(ctx *gin.Context) {
-// 	sessionID, err := ctx.Cookie("session_id")
-// 	if err != nil {
-// 		ctx.JSON(http.StatusNotFound, errorResponse(errors.New(SESSION_NOT_ESTABLISHED)))
-// 		return
-// 	}
-
-// 	session, err := server.store.GetSession(ctx, sessionID)
-// 	if err != nil {
-// 		if err == sql.ErrNoRows {
-// 			ctx.JSON(http.StatusNotFound, errorResponse(errors.New(SESSION_NOT_FOUND)))
-// 			return
-// 		}
-// 		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
-// 		return
-// 	}
-
-// 	ctx.JSON(http.StatusOK, getSessionResponse{
-// 		IsLoggedIn: time.Now().Before(session.ExpiresAt),
-// 	})
-// }

--- a/api/session.go
+++ b/api/session.go
@@ -1,0 +1,66 @@
+package api
+
+import (
+	"database/sql"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	SESSION_NOT_ESTABLISHED = "No session has been established. Login or register for an account"
+)
+
+type validateSessionResponse struct {
+	IsLoggedIn bool `json:"isLoggedIn"`
+}
+
+func (server *Server) validateSession(ctx *gin.Context) {
+	sessionID, err := ctx.Cookie("session_id")
+	if err != nil {
+		ctx.JSON(http.StatusNotFound, errorResponse(errors.New(SESSION_NOT_ESTABLISHED)))
+		return
+	}
+
+	session, err := server.store.GetSession(ctx, sessionID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			ctx.JSON(http.StatusNotFound, errorResponse(errors.New(SESSION_NOT_FOUND)))
+			return
+		}
+		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
+		return
+	}
+
+	ctx.JSON(http.StatusOK, validateSessionResponse{
+		IsLoggedIn: time.Now().Before(session.ExpiresAt),
+	})
+}
+
+// type getSessionResponse struct {
+// 	IsLoggedIn bool `json:"isLoggedIn"`
+// }
+
+// func (server *Server) getSession(ctx *gin.Context) {
+// 	sessionID, err := ctx.Cookie("session_id")
+// 	if err != nil {
+// 		ctx.JSON(http.StatusNotFound, errorResponse(errors.New(SESSION_NOT_ESTABLISHED)))
+// 		return
+// 	}
+
+// 	session, err := server.store.GetSession(ctx, sessionID)
+// 	if err != nil {
+// 		if err == sql.ErrNoRows {
+// 			ctx.JSON(http.StatusNotFound, errorResponse(errors.New(SESSION_NOT_FOUND)))
+// 			return
+// 		}
+// 		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
+// 		return
+// 	}
+
+// 	ctx.JSON(http.StatusOK, getSessionResponse{
+// 		IsLoggedIn: time.Now().Before(session.ExpiresAt),
+// 	})
+// }

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -90,8 +90,14 @@ func TestCreateUser(t *testing.T) {
 					LastName:     user.LastName,
 					EmailAddress: user.EmailAddress,
 				}
-				store.EXPECT().GetUserByEmail(gomock.Any(), user.EmailAddress).Times(1).Return(getUserByEmailRes, nil)
-				store.EXPECT().NewUserTx(gomock.Any(), EqCreateUserParams(args, user.Password)).Times(1).Return(newUserTxRes, nil)
+				store.EXPECT().
+					GetUserByEmail(gomock.Any(), user.EmailAddress).
+					Times(1).
+					Return(getUserByEmailRes, nil)
+				store.EXPECT().
+					NewUserTx(gomock.Any(), EqCreateUserParams(args, user.Password)).
+					Times(1).
+					Return(newUserTxRes, nil)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusOK, recorder.Code)
@@ -103,7 +109,10 @@ func TestCreateUser(t *testing.T) {
 			Body: gin.H{},
 			buildStubs: func(store *mockdb.MockStore) {
 				args := db.CreateUserParams{}
-				store.EXPECT().NewUserTx(gomock.Any(), gomock.Eq(args)).Times(0).Return(db.NewUserTxResults{}, sql.ErrTxDone)
+				store.EXPECT().
+					NewUserTx(gomock.Any(), gomock.Eq(args)).
+					Times(0).
+					Return(db.NewUserTxResults{}, sql.ErrTxDone)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusBadRequest, recorder.Code)
@@ -123,7 +132,10 @@ func TestCreateUser(t *testing.T) {
 					LastName:     user.LastName,
 					EmailAddress: "notFound@gmail.com",
 				}
-				store.EXPECT().NewUserTx(gomock.Any(), EqCreateUserParams(args, user.Password)).Times(1).Return(db.NewUserTxResults{}, sql.ErrTxDone)
+				store.EXPECT().
+					NewUserTx(gomock.Any(), EqCreateUserParams(args, user.Password)).
+					Times(1).
+					Return(db.NewUserTxResults{}, sql.ErrTxDone)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusInternalServerError, recorder.Code)
@@ -143,8 +155,14 @@ func TestCreateUser(t *testing.T) {
 					LastName:     user.LastName,
 					EmailAddress: user.EmailAddress,
 				}
-				store.EXPECT().NewUserTx(gomock.Any(), EqCreateUserParams(args, user.Password)).Times(1).Return(newUserTxRes, nil)
-				store.EXPECT().GetUserByEmail(gomock.Any(), user.EmailAddress).Times(1).Return(db.GetUserByEmailRow{}, sql.ErrNoRows)
+				store.EXPECT().
+					NewUserTx(gomock.Any(), EqCreateUserParams(args, user.Password)).
+					Times(1).
+					Return(newUserTxRes, nil)
+				store.EXPECT().
+					GetUserByEmail(gomock.Any(), user.EmailAddress).
+					Times(1).
+					Return(db.GetUserByEmailRow{}, sql.ErrNoRows)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusNotFound, recorder.Code)
@@ -164,8 +182,14 @@ func TestCreateUser(t *testing.T) {
 					LastName:     user.LastName,
 					EmailAddress: user.EmailAddress,
 				}
-				store.EXPECT().NewUserTx(gomock.Any(), EqCreateUserParams(args, user.Password)).Times(1).Return(newUserTxRes, nil)
-				store.EXPECT().GetUserByEmail(gomock.Any(), user.EmailAddress).Times(1).Return(db.GetUserByEmailRow{}, sql.ErrConnDone)
+				store.EXPECT().
+					NewUserTx(gomock.Any(), EqCreateUserParams(args, user.Password)).
+					Times(1).
+					Return(newUserTxRes, nil)
+				store.EXPECT().
+					GetUserByEmail(gomock.Any(), user.EmailAddress).
+					Times(1).
+					Return(db.GetUserByEmailRow{}, sql.ErrConnDone)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusInternalServerError, recorder.Code)
@@ -188,7 +212,7 @@ func TestCreateUser(t *testing.T) {
 			payload, err := json.Marshal(tc.Body)
 			require.NoError(t, err)
 
-			url := "/createUser"
+			url := "/api/createUser"
 			request, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(payload))
 			require.NoError(t, err)
 
@@ -230,10 +254,20 @@ func TestGetUserByEmail(t *testing.T) {
 			Name:         "OK",
 			EmailAddress: user.EmailAddress,
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
-				store.EXPECT().GetUserByEmail(gomock.Any(), user.EmailAddress).Times(1).Return(getUserByEmailRes, nil)
+				store.EXPECT().
+					GetUserByEmail(gomock.Any(), user.EmailAddress).
+					Times(1).
+					Return(getUserByEmailRes, nil)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusOK, recorder.Code)
@@ -244,10 +278,20 @@ func TestGetUserByEmail(t *testing.T) {
 			Name:         "Bad Request",
 			EmailAddress: "test",
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
-				store.EXPECT().GetUserByEmail(gomock.Any(), "test").Times(0).Return(db.GetUserByEmailRow{}, sql.ErrConnDone)
+				store.EXPECT().
+					GetUserByEmail(gomock.Any(), "test").
+					Times(0).
+					Return(db.GetUserByEmailRow{}, sql.ErrConnDone)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusBadRequest, recorder.Code)
@@ -257,10 +301,20 @@ func TestGetUserByEmail(t *testing.T) {
 			Name:         "Not Found",
 			EmailAddress: "thurnis@gmail.com",
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
-				store.EXPECT().GetUserByEmail(gomock.Any(), gomock.Eq("thurnis@gmail.com")).Times(1).Return(db.GetUserByEmailRow{}, sql.ErrNoRows)
+				store.EXPECT().
+					GetUserByEmail(gomock.Any(), gomock.Eq("thurnis@gmail.com")).
+					Times(1).
+					Return(db.GetUserByEmailRow{}, sql.ErrNoRows)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusNotFound, recorder.Code)
@@ -270,10 +324,20 @@ func TestGetUserByEmail(t *testing.T) {
 			Name:         "Internal Error",
 			EmailAddress: user.EmailAddress,
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
-				store.EXPECT().GetUserByEmail(gomock.Any(), user.EmailAddress).Times(1).Return(db.GetUserByEmailRow{}, sql.ErrConnDone)
+				store.EXPECT().
+					GetUserByEmail(gomock.Any(), user.EmailAddress).
+					Times(1).
+					Return(db.GetUserByEmailRow{}, sql.ErrConnDone)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusInternalServerError, recorder.Code)
@@ -294,10 +358,20 @@ func TestGetUserByEmail(t *testing.T) {
 			Name:         "Unauthorized -> using different account",
 			EmailAddress: user.EmailAddress,
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, uuid.New().String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					uuid.New().String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
-				store.EXPECT().GetUserByEmail(gomock.Any(), user.EmailAddress).Times(1).Return(getUserByEmailRes, nil)
+				store.EXPECT().
+					GetUserByEmail(gomock.Any(), user.EmailAddress).
+					Times(1).
+					Return(getUserByEmailRes, nil)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusUnauthorized, recorder.Code)
@@ -317,7 +391,7 @@ func TestGetUserByEmail(t *testing.T) {
 			server := newTestServer(t, store)
 			recorder := httptest.NewRecorder()
 
-			url := fmt.Sprintf("/getUserByEmail/%s", tc.EmailAddress)
+			url := fmt.Sprintf("/api/getUserByEmail/%s", tc.EmailAddress)
 			request, err := http.NewRequest(http.MethodGet, url, nil)
 			require.NoError(t, err)
 
@@ -390,12 +464,25 @@ func TestUpdateUser(t *testing.T) {
 				"id":           userID.String(),
 			},
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
-				store.EXPECT().GetUserById(gomock.Any(), gomock.Eq(userID.String())).Times(1).Return(preGetUserByID, nil)
+				store.EXPECT().
+					GetUserById(gomock.Any(), gomock.Eq(userID.String())).
+					Times(1).
+					Return(preGetUserByID, nil)
 				store.EXPECT().UpdateUser(gomock.Any(), gomock.Eq(newUserData)).Times(1).Return(nil)
-				store.EXPECT().GetUserById(gomock.Any(), gomock.Eq(userID.String())).Times(1).Return(postGetUserByID, nil)
+				store.EXPECT().
+					GetUserById(gomock.Any(), gomock.Eq(userID.String())).
+					Times(1).
+					Return(postGetUserByID, nil)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusOK, recorder.Code)
@@ -406,10 +493,20 @@ func TestUpdateUser(t *testing.T) {
 			Name: "Bad Request",
 			Body: gin.H{},
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
-				store.EXPECT().GetUserById(gomock.Any(), gomock.Any()).Times(0).Return(db.GetUserByIdRow{}, sql.ErrConnDone)
+				store.EXPECT().
+					GetUserById(gomock.Any(), gomock.Any()).
+					Times(0).
+					Return(db.GetUserByIdRow{}, sql.ErrConnDone)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusBadRequest, recorder.Code)
@@ -424,11 +521,24 @@ func TestUpdateUser(t *testing.T) {
 				"id":           userID.String(),
 			},
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
-				store.EXPECT().GetUserById(gomock.Any(), gomock.Eq(userID.String())).Times(1).Return(preGetUserByID, nil)
-				store.EXPECT().UpdateUser(gomock.Any(), gomock.Eq(newUserData)).Times(1).Return(sql.ErrConnDone)
+				store.EXPECT().
+					GetUserById(gomock.Any(), gomock.Eq(userID.String())).
+					Times(1).
+					Return(preGetUserByID, nil)
+				store.EXPECT().
+					UpdateUser(gomock.Any(), gomock.Eq(newUserData)).
+					Times(1).
+					Return(sql.ErrConnDone)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusInternalServerError, recorder.Code)
@@ -443,11 +553,24 @@ func TestUpdateUser(t *testing.T) {
 				"id":           userID.String(),
 			},
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
-				store.EXPECT().GetUserById(gomock.Any(), gomock.Eq(userID.String())).Times(1).Return(db.GetUserByIdRow{}, sql.ErrNoRows)
-				store.EXPECT().UpdateUser(gomock.Any(), gomock.Eq(newUserData)).Times(0).Return(sql.ErrConnDone)
+				store.EXPECT().
+					GetUserById(gomock.Any(), gomock.Eq(userID.String())).
+					Times(1).
+					Return(db.GetUserByIdRow{}, sql.ErrNoRows)
+				store.EXPECT().
+					UpdateUser(gomock.Any(), gomock.Eq(newUserData)).
+					Times(0).
+					Return(sql.ErrConnDone)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusNotFound, recorder.Code)
@@ -462,11 +585,24 @@ func TestUpdateUser(t *testing.T) {
 				"id":           userID.String(),
 			},
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
-				store.EXPECT().GetUserById(gomock.Any(), gomock.Eq(userID.String())).Times(1).Return(db.GetUserByIdRow{}, sql.ErrConnDone)
-				store.EXPECT().UpdateUser(gomock.Any(), gomock.Eq(newUserData)).Times(0).Return(sql.ErrConnDone)
+				store.EXPECT().
+					GetUserById(gomock.Any(), gomock.Eq(userID.String())).
+					Times(1).
+					Return(db.GetUserByIdRow{}, sql.ErrConnDone)
+				store.EXPECT().
+					UpdateUser(gomock.Any(), gomock.Eq(newUserData)).
+					Times(0).
+					Return(sql.ErrConnDone)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusInternalServerError, recorder.Code)
@@ -481,12 +617,25 @@ func TestUpdateUser(t *testing.T) {
 				"id":           userID.String(),
 			},
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
-				store.EXPECT().GetUserById(gomock.Any(), gomock.Eq(userID.String())).Times(1).Return(preGetUserByID, nil)
+				store.EXPECT().
+					GetUserById(gomock.Any(), gomock.Eq(userID.String())).
+					Times(1).
+					Return(preGetUserByID, nil)
 				store.EXPECT().UpdateUser(gomock.Any(), gomock.Eq(newUserData)).Times(1).Return(nil)
-				store.EXPECT().GetUserById(gomock.Any(), gomock.Eq(userID.String())).Times(1).Return(db.GetUserByIdRow{}, sql.ErrConnDone)
+				store.EXPECT().
+					GetUserById(gomock.Any(), gomock.Eq(userID.String())).
+					Times(1).
+					Return(db.GetUserByIdRow{}, sql.ErrConnDone)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusInternalServerError, recorder.Code)
@@ -518,10 +667,20 @@ func TestUpdateUser(t *testing.T) {
 				"id":           userID.String(),
 			},
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, uuid.New().String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					uuid.New().String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
-				store.EXPECT().GetUserById(gomock.Any(), gomock.Eq(userID.String())).Times(1).Return(preGetUserByID, nil)
+				store.EXPECT().
+					GetUserById(gomock.Any(), gomock.Eq(userID.String())).
+					Times(1).
+					Return(preGetUserByID, nil)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusUnauthorized, recorder.Code)
@@ -544,7 +703,7 @@ func TestUpdateUser(t *testing.T) {
 			data, err := json.Marshal(tc.Body)
 			require.NoError(t, err)
 
-			url := "/updateUser"
+			url := "/api/updateUser"
 			request, err := http.NewRequest(http.MethodPatch, url, bytes.NewReader(data))
 			require.NoError(t, err)
 
@@ -580,7 +739,14 @@ func TestChangePassword(t *testing.T) {
 			Name: "Bad Request",
 			Body: gin.H{},
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
 			},
@@ -596,10 +762,20 @@ func TestChangePassword(t *testing.T) {
 				"newPassword":     "shannonsbosoms@69",
 			},
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
-				store.EXPECT().GetUserById(gomock.Any(), gomock.Eq(userID.String())).Times(1).Return(db.GetUserByIdRow{}, sql.ErrNoRows)
+				store.EXPECT().
+					GetUserById(gomock.Any(), gomock.Eq(userID.String())).
+					Times(1).
+					Return(db.GetUserByIdRow{}, sql.ErrNoRows)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusNotFound, recorder.Code)
@@ -613,10 +789,20 @@ func TestChangePassword(t *testing.T) {
 				"newPassword":     "shannonsbosoms@69",
 			},
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
-				store.EXPECT().GetUserById(gomock.Any(), gomock.Eq(userID.String())).Times(1).Return(db.GetUserByIdRow{}, sql.ErrConnDone)
+				store.EXPECT().
+					GetUserById(gomock.Any(), gomock.Eq(userID.String())).
+					Times(1).
+					Return(db.GetUserByIdRow{}, sql.ErrConnDone)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusInternalServerError, recorder.Code)
@@ -630,10 +816,20 @@ func TestChangePassword(t *testing.T) {
 				"newPassword":     "shannonsbosoms@69",
 			},
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
-				store.EXPECT().GetUserById(gomock.Any(), gomock.Eq(userID.String())).Times(1).Return(getUserByIdRes, nil)
+				store.EXPECT().
+					GetUserById(gomock.Any(), gomock.Eq(userID.String())).
+					Times(1).
+					Return(getUserByIdRes, nil)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusUnauthorized, recorder.Code)
@@ -647,15 +843,28 @@ func TestChangePassword(t *testing.T) {
 				"newPassword":     "shannonsbosoms@69",
 			},
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
 				args := db.ChangePasswordParams{
 					UserID:   userID.String(),
 					Password: "shannonsbosoms@69",
 				}
-				store.EXPECT().GetUserById(gomock.Any(), gomock.Eq(userID.String())).Times(1).Return(getUserByIdRes, nil)
-				store.EXPECT().ChangePassword(gomock.Any(), gomock.Eq(args)).Times(1).Return(sql.ErrConnDone)
+				store.EXPECT().
+					GetUserById(gomock.Any(), gomock.Eq(userID.String())).
+					Times(1).
+					Return(getUserByIdRes, nil)
+				store.EXPECT().
+					ChangePassword(gomock.Any(), gomock.Eq(args)).
+					Times(1).
+					Return(sql.ErrConnDone)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusInternalServerError, recorder.Code)
@@ -669,14 +878,24 @@ func TestChangePassword(t *testing.T) {
 				"newPassword":     "shannonsbosoms@69",
 			},
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
 				args := db.ChangePasswordParams{
 					UserID:   userID.String(),
 					Password: "shannonsbosoms@69",
 				}
-				store.EXPECT().GetUserById(gomock.Any(), gomock.Eq(userID.String())).Times(1).Return(getUserByIdRes, nil)
+				store.EXPECT().
+					GetUserById(gomock.Any(), gomock.Eq(userID.String())).
+					Times(1).
+					Return(getUserByIdRes, nil)
 				store.EXPECT().ChangePassword(gomock.Any(), gomock.Eq(args)).Times(1).Return(nil)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
@@ -704,10 +923,20 @@ func TestChangePassword(t *testing.T) {
 				"newPassword":     "shannonsbosoms@69",
 			},
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, uuid.New().String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					uuid.New().String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
-				store.EXPECT().GetUserById(gomock.Any(), gomock.Eq(userID.String())).Times(1).Return(getUserByIdRes, nil)
+				store.EXPECT().
+					GetUserById(gomock.Any(), gomock.Eq(userID.String())).
+					Times(1).
+					Return(getUserByIdRes, nil)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusUnauthorized, recorder.Code)
@@ -730,7 +959,7 @@ func TestChangePassword(t *testing.T) {
 			data, err := json.Marshal(tc.Body)
 			require.NoError(t, err)
 
-			url := "/changePassword"
+			url := "/api/changePassword"
 			request, err := http.NewRequest(http.MethodPatch, url, bytes.NewReader(data))
 			require.NoError(t, err)
 
@@ -765,10 +994,20 @@ func TestDeleteUser(t *testing.T) {
 			Name:   "Not found -> Get User",
 			UserID: userID.String(),
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
-				store.EXPECT().GetUserById(gomock.Any(), gomock.Eq(userID.String())).Times(1).Return(db.GetUserByIdRow{}, sql.ErrNoRows)
+				store.EXPECT().
+					GetUserById(gomock.Any(), gomock.Eq(userID.String())).
+					Times(1).
+					Return(db.GetUserByIdRow{}, sql.ErrNoRows)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusNotFound, recorder.Code)
@@ -778,10 +1017,20 @@ func TestDeleteUser(t *testing.T) {
 			Name:   "Internal Error -> Get User",
 			UserID: userID.String(),
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
-				store.EXPECT().GetUserById(gomock.Any(), gomock.Eq(userID.String())).Times(1).Return(db.GetUserByIdRow{}, sql.ErrConnDone)
+				store.EXPECT().
+					GetUserById(gomock.Any(), gomock.Eq(userID.String())).
+					Times(1).
+					Return(db.GetUserByIdRow{}, sql.ErrConnDone)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusInternalServerError, recorder.Code)
@@ -791,11 +1040,24 @@ func TestDeleteUser(t *testing.T) {
 			Name:   "Internal Error -> Delete User",
 			UserID: userID.String(),
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
-				store.EXPECT().GetUserById(gomock.Any(), gomock.Eq(userID.String())).Times(1).Return(getUserByIdRes, nil)
-				store.EXPECT().DeleteUser(gomock.Any(), gomock.Eq(userID.String())).Times(1).Return(sql.ErrConnDone)
+				store.EXPECT().
+					GetUserById(gomock.Any(), gomock.Eq(userID.String())).
+					Times(1).
+					Return(getUserByIdRes, nil)
+				store.EXPECT().
+					DeleteUser(gomock.Any(), gomock.Eq(userID.String())).
+					Times(1).
+					Return(sql.ErrConnDone)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusInternalServerError, recorder.Code)
@@ -805,11 +1067,24 @@ func TestDeleteUser(t *testing.T) {
 			Name:   "OK -> No Content",
 			UserID: userID.String(),
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, userID.String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					userID.String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
-				store.EXPECT().GetUserById(gomock.Any(), gomock.Eq(userID.String())).Times(1).Return(getUserByIdRes, nil)
-				store.EXPECT().DeleteUser(gomock.Any(), gomock.Eq(userID.String())).Times(1).Return(nil)
+				store.EXPECT().
+					GetUserById(gomock.Any(), gomock.Eq(userID.String())).
+					Times(1).
+					Return(getUserByIdRes, nil)
+				store.EXPECT().
+					DeleteUser(gomock.Any(), gomock.Eq(userID.String())).
+					Times(1).
+					Return(nil)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusNoContent, recorder.Code)
@@ -828,10 +1103,20 @@ func TestDeleteUser(t *testing.T) {
 			Name:   "Unauthorized -> using different account",
 			UserID: userID.String(),
 			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
-				addAuthorization(t, request, tokenMaker, authorizationBearerType, uuid.New().String(), time.Minute)
+				addAuthorization(
+					t,
+					request,
+					tokenMaker,
+					authorizationBearerType,
+					uuid.New().String(),
+					time.Minute,
+				)
 			},
 			buildStubs: func(store *mockdb.MockStore) {
-				store.EXPECT().GetUserById(gomock.Any(), gomock.Eq(userID.String())).Times(1).Return(getUserByIdRes, nil)
+				store.EXPECT().
+					GetUserById(gomock.Any(), gomock.Eq(userID.String())).
+					Times(1).
+					Return(getUserByIdRes, nil)
 			},
 			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusUnauthorized, recorder.Code)
@@ -851,7 +1136,7 @@ func TestDeleteUser(t *testing.T) {
 			server := newTestServer(t, store)
 			recorder := httptest.NewRecorder()
 
-			url := fmt.Sprintf("/deleteUser/%s", tc.UserID)
+			url := fmt.Sprintf("/api/deleteUser/%s", tc.UserID)
 			request, err := http.NewRequest(http.MethodDelete, url, nil)
 			require.NoError(t, err)
 


### PR DESCRIPTION
- Add new validateSession service that checks for the http only session id and returns weather the users session is expired or not
- previously, on the client end, I was using the renew token service to validate the session. It works, but is a bit wasteful in my opinion. The goal is to use this service on the home page, login page and registration page. The API is only invoked one time if any of those pages are hit and it's goal is to redirect the user to the dashboard. The dashboard is where renewToken should be called. 
- The main goal is to help keep users logged in for longer 
