### PR TITLE
[EDIT] server/ui are on same domains now

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -116,8 +116,7 @@ func (server *Server) login(ctx *gin.Context) {
 		Secure:   true,
 		HttpOnly: true,
 		Expires:  session.ExpiresAt,
-		SameSite: http.SameSiteNoneMode,
-		MaxAge:   3600,
+		SameSite: http.SameSiteStrictMode,
 		Path:     "/api",
 	})
 


### PR DESCRIPTION
Cookie fixes. There were a couple of issues. First one being, expires and max age were both set. The refresh tokens expiry time is used in this case so it makes sense to remove max age. 

There was an issue on mobile browsers where cookies were not being set because of SameSite settings. I didn't realize this but my custom domain for the server wasn't configured. I was able to resolve that in AWS and now both my UI and server are on the same domain and cookies are properly set on mobile browsers.

I am reverting my change of setting same site to none in a previous PR. 