### PR TITLE
Wo queries

### DIFF
--- a/api/profile_test.go
+++ b/api/profile_test.go
@@ -223,22 +223,6 @@ func TestCreateProfile(t *testing.T) {
 				})
 			},
 		},
-		{
-			Name: "Unauthorized",
-			Body: gin.H{
-				"country":           profile.Country,
-				"measurementSystem": profile.MeasurementSystem,
-				"bodyWeight":        profile.BodyWeight,
-				"bodyFat":           profile.BodyFat,
-				"timeZoneOffset":    profile.TimezoneOffset,
-				"userID":            userID.String(),
-			},
-			setupAuth:  func(t *testing.T, request *http.Request, tokenMaker token.Maker) {},
-			buildStubs: func(store *mockdb.MockStore) {},
-			checkRes: func(t *testing.T, recorder *httptest.ResponseRecorder) {
-				require.Equal(t, http.StatusUnauthorized, recorder.Code)
-			},
-		},
 	}
 
 	for i := range testCases {

--- a/api/server.go
+++ b/api/server.go
@@ -92,6 +92,8 @@ func (server *Server) setupRouter() {
 	protected.GET("/getMaxLiftsByExercise/:exercise_name", server.getMaxLiftsByExercise)
 	protected.GET("/getMaxLiftsByMuscleGroup/:muscle_group", server.getMaxLiftsByMuscleGroup)
 	protected.GET("/getMaxRepLifts/:limit", server.getMaxRepLifts)
+	protected.GET("/getTotalWorkouts", server.getTotalWorkouts)
+	protected.GET("/getLastWorkout", server.getLastWorkoutDate)
 	protected.PATCH("/updateLift", server.updateLift)
 	protected.DELETE("/deleteLift/:id", server.deleteLift)
 

--- a/api/server.go
+++ b/api/server.go
@@ -57,6 +57,7 @@ func (server *Server) setupRouter() {
 	api := router.Group("/api")
 
 	api.POST("/createUser", server.createUser)
+	api.POST("/createProfile", server.createProfile)
 	api.POST("/auth/login", server.login)
 	api.POST("/auth/renewToken", server.renewToken)
 	api.GET("/validateSession", server.validateSession)
@@ -68,7 +69,6 @@ func (server *Server) setupRouter() {
 	protected.PATCH("/changePassword", server.changePassword)
 	protected.DELETE("/deleteUser/:id", server.deleteUser)
 
-	protected.POST("/createProfile", server.createProfile)
 	protected.GET("/getProfile/:user_id", server.getProfile)
 	protected.PATCH("/updateProfile", server.updateProfile)
 	protected.DELETE("/deleteProfile/:user_id", server.deleteProfile)

--- a/api/workout.go
+++ b/api/workout.go
@@ -109,6 +109,42 @@ func (server *Server) listWorkouts(ctx *gin.Context) {
 	})
 }
 
+type getTotalWorkoutsResponse struct {
+	CompletedWorkouts int64 `json:"completedWorkouts"`
+}
+
+func (server *Server) getTotalWorkouts(ctx *gin.Context) {
+	authHeader := ctx.MustGet(authorizationPayloadKey).(*token.Payload)
+
+	recordCount, err := server.store.GetTotalWorkouts(ctx, authHeader.UserID)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
+		return
+	}
+
+	ctx.JSON(http.StatusOK, getTotalWorkoutsResponse{
+		CompletedWorkouts: recordCount,
+	})
+}
+
+type getLastWorkoutDateResposne struct {
+	LastWorkoutDate time.Time `json:"lastWorkoutDate"`
+}
+
+func (server *Server) getLastWorkoutDate(ctx *gin.Context) {
+	authHeader := ctx.MustGet(authorizationPayloadKey).(*token.Payload)
+
+	workout, err := server.store.GetLastWorkout(ctx, authHeader.UserID)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
+		return
+	}
+
+	ctx.JSON(http.StatusOK, getLastWorkoutDateResposne{
+		LastWorkoutDate: workout.CompletedDate.Time,
+	})
+}
+
 type updateWorkoutRequest struct {
 	ID            int32           `json:"id"`
 	Duration      string          `json:"duration"`


### PR DESCRIPTION
profile creation was set as a protected route, this lead to the user not being able to finish the profile creation unless a bearer token was passed in the request header. Moved out of protected routes.
Added a few new queries as well for getting last workout date and total workout record count. 